### PR TITLE
Add new fields for Tail Number and Airline

### DIFF
--- a/client/components/SingleFlight.tsx
+++ b/client/components/SingleFlight.tsx
@@ -18,6 +18,8 @@ interface FlightPatchOptions {
     duration?: number;
     distance?: number;
     airplane?: string;
+    tailNumber?: string;
+    airline?: string;
     flight_number?: string;
     notes?: string;
 }
@@ -144,22 +146,30 @@ export default function SingleFlight({ flightID }) {
                     <Subheading text="Other" />
                     { editMode ?
                     <>
-                        <p>Seat: <Select name="seat" onChange={handleInputChange} options={[
-                            { text: "Choose", value: "" },
-                            { text: "Aisle", value: "aisle" },
-                            { text: "Middle", value: "middle" },
-                            { text: "Window", value: "window" }
-                        ]} /></p>
-                        <p>Class: <Select name="ticketClass" onChange={handleInputChange} options={[
-                            { text: "Choose", value: "" },
-                            { text: "Private", value: "private" },
-                            { text: "First", value: "first" },
-                            { text: "Business", value: "business" },
-                            { text: "Economy+", value: "economy+" },
-                            { text: "Economy", value: "economy" }
-                        ]} /></p>
-                        <p>Airplane: <Input type="text" name="airplane" onChange={handleInputChange} /></p>
-                        <p>Flight Number: <Input type="text" name="flightNumber" onChange={handleInputChange} /></p>
+                        <div className="flex space-x-4">
+                            <p>Seat: <Select name="seat" onChange={handleInputChange} options={[
+                                { text: "Choose", value: "" },
+                                { text: "Aisle", value: "aisle" },
+                                { text: "Middle", value: "middle" },
+                                { text: "Window", value: "window" }
+                            ]} /></p>
+                            <p>Class: <Select name="ticketClass" onChange={handleInputChange} options={[
+                                { text: "Choose", value: "" },
+                                { text: "Private", value: "private" },
+                                { text: "First", value: "first" },
+                                { text: "Business", value: "business" },
+                                { text: "Economy+", value: "economy+" },
+                                { text: "Economy", value: "economy" }
+                            ]} /></p>
+                        </div>
+                        <div className="flex space-x-4">
+                            <p>Airplane: <Input type="text" name="airplane" onChange={handleInputChange} /></p>
+                            <p>Tail Number: <Input type="text" name="tailNumber" onChange={handleInputChange} /></p>
+                        </div>
+                        <div className="flex space-x-4">
+                            <p>Airline: <Input type="text" name="airline" onChange={handleInputChange} /></p>
+                            <p>Flight Number: <Input type="text" name="flightNumber" onChange={handleInputChange} /></p>
+                        </div>
                         <p>Notes</p>
                         <TextArea name="notes" onChange={handleInputChange}/>
                     </>
@@ -168,7 +178,8 @@ export default function SingleFlight({ flightID }) {
                         <p>Seat: <span>{flight.seat || "N/A"}</span></p>
                         <p>Class: <span>{flight.ticketClass || "N/A"}</span></p>
                         <p>Airplane: <span>{flight.airplane || "N/A"}</span></p>
-                        <p>Flight Number: <span>{flight.flightNumber || "N/A"}</span></p>
+                        <p>Tail Number: <span>{flight.tailNumber || "N/A"}</span></p>
+                        <p>Flight Number: <span>{flight.airline || ""} {flight.flightNumber || "N/A"}</span></p>
                         <p>Notes: {flight.notes || "N/A"}</p>
                     </>}
                 </div>

--- a/client/models.ts
+++ b/client/models.ts
@@ -11,6 +11,8 @@ export class Flight {
     duration: number;
     distance: number;
     airplane: string;
+    tailNumber: string;
+    airline: string;
     flightNumber: string;
     notes: string;
 }

--- a/client/pages/AllFlights.tsx
+++ b/client/pages/AllFlights.tsx
@@ -146,6 +146,7 @@ function FlightsTable({ filters }: { filters: FlightsFilters }) {
                 <TableHeading text="Seat"/>
                 <TableHeading text="Class"/>
                 <TableHeading text="Airplane"/>
+                <TableHeading text="Airline"/>
                 <TableHeading text="Flight Number"/>
             </tr>
             { flights.map((flight: Flight) => (
@@ -161,6 +162,7 @@ function FlightsTable({ filters }: { filters: FlightsFilters }) {
                 <TableCell text={flight.seat || ""}/>
                 <TableCell text={flight.ticketClass || ""} />
                 <TableCell text={flight.airplane || ""}/>
+                <TableCell text={flight.airline || ""}/>
                 <TableCell text={flight.flightNumber || ""}/>
             </tr>
             ))}

--- a/client/pages/New.tsx
+++ b/client/pages/New.tsx
@@ -86,46 +86,78 @@ function FlightDetails() {
                 </div>
 
                 <div className="container">
-                    <Label text="Seat Type"/>
-                    <Select name="seat"
-                            value={flight.seat}
-                            onChange={handleChange}
-                            options={[
-                                { text: "Choose", value: "" },
-                                { text: "Aisle", value: "aisle" },
-                                { text: "Middle", value: "middle" },
-                                { text: "Window", value: "window" }
-                            ]} />
+                    <div className="flex space-x-4">
+                        <div className="flex flex-col">
+                            <Label text="Seat Type"/>
+                            <Select name="seat"
+                                    value={flight.seat}
+                                    onChange={handleChange}
+                                    options={[
+                                        { text: "Choose", value: "" },
+                                        { text: "Aisle", value: "aisle" },
+                                        { text: "Middle", value: "middle" },
+                                        { text: "Window", value: "window" }
+                                    ]} />
+                            <br />
+                        </div>
+                        <div className="flex flex-col">
+                            <Label text="Class"/>
+                            <Select name="ticketClass"
+                                    value={flight.ticketClass}
+                                    onChange={handleChange}
+                                    options={[
+                                        { text: "Choose", value: "" },
+                                        { text: "Private", value: "private" },
+                                        { text: "First", value: "first" },
+                                        { text: "Business", value: "business" },
+                                        { text: "Economy+", value: "economy+" },
+                                        { text: "Economy", value: "economy" }
+                                    ]} />
+                            <br />
+                        </div>
+                    </div>
+                    <div className="flex space-x-4">
+                        <div className="flex flex-col">
+                            <Label text="Airplane"/>
+                            <Input type="text"
+                                name="airplane"
+                                value={flight.airplane}
+                                placeholder="ICAO code (ex: B738)"
+                                maxLength={16}
+                                onChange={handleChange} />
+                        </div>
+                        <div className="flex flex-col">
+                            <Label text="Tail Number"/>
+                            <Input type="text"
+                                name="tailNumber"
+                                value={flight.tailNumber}
+                                placeholder="A6-EVS"
+                                maxLength={16}
+                                onChange={handleChange} />
+                        </div>
+                    </div>
                     <br />
-                    <Label text="Class"/>
-                    <Select name="ticketClass"
-                            value={flight.ticketClass}
-                            onChange={handleChange}
-                            options={[
-                                { text: "Choose", value: "" },
-                                { text: "Private", value: "private" },
-                                { text: "First", value: "first" },
-                                { text: "Business", value: "business" },
-                                { text: "Economy+", value: "economy+" },
-                                { text: "Economy", value: "economy" }
-                            ]} />
+                    <div className="flex space-x-4">
+                        <div className="flex flex-col">
+                            <Label text="Airline"/>
+                            <Input type="text"
+                                name="airline"
+                                value={flight.airline}
+                                placeholder="ICAO code (ex: BAW)"
+                                maxLength={7}
+                                onChange={handleChange} />
+                        </div>
+                        <div className="flex flex-col">
+                            <Label text="Flight Number"/>
+                            <Input type="text"
+                                name="flightNumber"
+                                value={flight.flightNumber}
+                                placeholder="1234"
+                                maxLength={7}
+                                onChange={handleChange} />
+                        </div>
                     <br />
-                    <Label text="Airplane"/>
-                    <Input type="text"
-                           name="airplane"
-                           value={flight.airplane}
-                           placeholder="B738"
-                           maxLength={16}
-                           onChange={handleChange} />
-                    <br />
-                    <Label text="Flight Number"/>
-                    <Input type="text"
-                           name="flightNumber"
-                           value={flight.flightNumber}
-                           placeholder="FR2460"
-                           maxLength={7}
-                           onChange={handleChange} />
-                    <br />
+                    </div>
                     <Label text="Notes"/>
                     <TextArea name="notes"
                               value={flight.notes}

--- a/server/database.py
+++ b/server/database.py
@@ -22,6 +22,8 @@ class Database():
             duration       INTEGER,
             distance       INTEGER,
             airplane       TEXT,
+            tail_number    TEXT,
+            airline        TEXT,
             flight_number  TEXT,
             notes          TEXT
         )"""
@@ -104,6 +106,7 @@ class Database():
         self.execute_query(f"INSERT INTO _flights ({', '.join(present)}) SELECT * FROM flights;")
         self.execute_query("DROP TABLE flights;")
         self.execute_query("ALTER TABLE _flights RENAME TO flights;")
+        print("Successfully patched flights table")
 
     def execute_query(self, query: str, parameters=[]) -> int:
         try:

--- a/server/models.py
+++ b/server/models.py
@@ -122,6 +122,8 @@ class FlightModel(CustomModel):
     duration:       int|None = None
     distance:       int|None = None
     airplane:       str|None = None
+    tail_number:    str|None = None
+    airline:        str|None = None
     flight_number:  str|None = None
     notes:          str|None = None
 


### PR DESCRIPTION
Closes #8

Add the following additional fields for flights:

- `tail_number`: String field for the tail number of the aircraft (ex: `N896FD`)
- `airline`: The 3-letter ICAO code of the airline operating the flight (ex: `BAW`)

I believe both of these fields will add a great additional dimension to flights, and the airline one in particular has already been requested as issue #8. I am also working on a PR for #51, which would greatly benefit from having a separate airline field, since that is data that was already stored.

Additionally, I started to enforce more that the airline code should be in ICAO format. Hopefully later on, this value can be used to display a more readable version of the airline (ex: Delta Airlines). It seems that the ICAO format was already preferred for airports, so I stuck to that.

Another minor change was to start enforcing that users must input the `flight_number` as a `number` going forward instead of a `string`. 

# Screenshots
## All Flights
<img width="1279" alt="jetlog_allflights_2" src="https://github.com/user-attachments/assets/054ba603-9fdc-4304-a567-fe83257f1d1b">

## Add New Flight
<img width="1440" alt="jetlog_newflight_2" src="https://github.com/user-attachments/assets/36257624-7d94-4606-b4cb-ef48386503c0">

## Flight Details
<img width="384" alt="jetlog_flightdetails" src="https://github.com/user-attachments/assets/0c2d8630-e531-4ba3-a662-6693a6d7c0fe">
