### PR TITLE
feat: Add Support for Authentication via HTTP Headers

### DIFF
--- a/client/api.ts
+++ b/client/api.ts
@@ -37,10 +37,17 @@ class APIClass {
 
     private handleError(err: any) {
         if (err.response) {
-            if (err.response.status === 401) {
+            const status = err.response.status;
+            const detail = err.response.data?.detail;
+
+            if (status === 401) {
                 if (window.location.pathname !== BASE_URL + "/login") {
                     window.location.href = BASE_URL + "/login";
                 }
+            }
+            if (status === 403 && detail?.includes("Username supplied in header")) {
+                alert(detail);
+                return;
             }
             else {
                 alert("Bad response: " + JSON.stringify(err.response.data));

--- a/client/api.ts
+++ b/client/api.ts
@@ -37,17 +37,10 @@ class APIClass {
 
     private handleError(err: any) {
         if (err.response) {
-            const status = err.response.status;
-            const detail = err.response.data?.detail;
-
-            if (status === 401) {
+            if (err.response.status === 401) {
                 if (window.location.pathname !== BASE_URL + "/login") {
                     window.location.href = BASE_URL + "/login";
                 }
-            }
-            if (status === 403 && detail?.includes("Username supplied in header")) {
-                alert(detail);
-                return;
             }
             else {
                 alert("Bad response: " + JSON.stringify(err.response.data));

--- a/server/auth/users.py
+++ b/server/auth/users.py
@@ -33,7 +33,7 @@ async def get_user_from_auth_header(request: Request) -> User:
     user = get_user(header_username)
 
     if not user:
-        raise HTTPException(status_code=401, detail="Username supplied in header does not exist, please have your instance admin create this user.")
+        raise HTTPException(status_code=403, detail="Username supplied in header does not exist, please have your instance admin create this user.")
 
     return user
 

--- a/server/auth/users.py
+++ b/server/auth/users.py
@@ -1,6 +1,6 @@
 from server.models import CustomModel, User
 from server.database import database
-from server.auth.utils import hash_password, get_user, generate_password, oauth2_scheme
+from server.auth.utils import hash_password, get_user, oauth2_scheme
 from server.environment import SECRET_KEY, AUTH_HEADER
 
 
@@ -31,16 +31,9 @@ async def get_user_from_auth_header(request: Request) -> User:
         raise HTTPException(status_code=401, detail="Missing authentication header")
 
     user = get_user(header_username)
-    if not user:
-        # Auto-create user
-        random_password = generate_password()
-        hashed_password = hash_password(random_password)
 
-        database.execute_query(
-            "INSERT INTO users (username, password_hash, is_admin) VALUES (?, ?, ?)",
-            [header_username, hashed_password, False]
-        )
-        user = get_user(header_username)
+    if not user:
+        raise HTTPException(status_code=401, detail="Username supplied in header does not exist, please have your instance admin create this user.")
 
     return user
 

--- a/server/auth/users.py
+++ b/server/auth/users.py
@@ -1,11 +1,11 @@
 from server.models import CustomModel, User
 from server.database import database
-from server.auth.utils import hash_password, get_user,  oauth2_scheme
-from server.environment import SECRET_KEY
+from server.auth.utils import hash_password, get_user, generate_password, oauth2_scheme
+from server.environment import SECRET_KEY, AUTH_HEADER
 
 
 import jwt
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 
 router = APIRouter(
     prefix="/users",
@@ -20,46 +20,91 @@ class UserPatch(CustomModel):
 
 ALGORITHM = "HS256"
 
-@router.get("/me")
-async def get_current_user(token: str = Depends(oauth2_scheme)) -> User:
+async def get_user_from_auth_header(request: Request) -> User:
+    """
+    Authenticate users via AUTH_HEADER.
+    Automatically creates the user if they do not exist.
+    """
+    header_username = request.headers.get(AUTH_HEADER)
+
+    if not header_username:
+        raise HTTPException(status_code=401, detail="Missing authentication header")
+
+    user = get_user(header_username)
+    if not user:
+        # Auto-create user
+        random_password = generate_password()
+        hashed_password = hash_password(random_password)
+
+        database.execute_query(
+            "INSERT INTO users (username, password_hash, is_admin) VALUES (?, ?, ?)",
+            [header_username, hashed_password, False]
+        )
+        user = get_user(header_username)
+
+    return user
+
+async def get_user_from_token(token: str = Depends(oauth2_scheme)) -> User:
+    """
+    Authenticate users via OAuth2 token.
+    """
     credentials_exception = HTTPException(
-            status_code=401,
-            headers={"WWW-Authenticate": "Bearer"},
-            detail="Invalid token")
+        status_code=401,
+        headers={"WWW-Authenticate": "Bearer"},
+        detail="Invalid token"
+    )
+
     try:
         payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
         username = payload.get("sub")
-
-        if username == None:
+        if username is None:
             raise credentials_exception
     except jwt.InvalidTokenError:
         raise credentials_exception
 
     user = get_user(username)
-
-    if user == None:
+    if user is None:
         raise credentials_exception
 
+    return user
+
+async def get_current_user(request: Request, token: str = Depends(oauth2_scheme)) -> User:
+    """
+    Use Auth Header if present, otherwise fallback to OAuth2 token.
+    """
+    if AUTH_HEADER in request.headers:
+        return await get_user_from_auth_header(request)
+
+    return await get_user_from_token(token)
+
+@router.get("/me")
+async def get_current_user_route(user: User = Depends(get_current_user)) -> User:
+    """
+    Returns the current authenticated user.
+    Automatically authenticates via AUTH_HEADER if available.
+    """
     return user
 
 @router.post("", status_code=201)
 async def create_user(new_user: UserPatch, user: User = Depends(get_current_user)):
     if not user.is_admin:
-        raise HTTPException(status_code=403, detail="Only admins change create new users")
+        raise HTTPException(status_code=403, detail="Only admins can create new users")
     if not new_user.username or not new_user.password:
         raise HTTPException(status_code=400, detail="Username and password are required fields")
-
     if len(new_user.username) < 1:
         raise HTTPException(status_code=400, detail="Username should be at least 1 character long")
 
     password_hash = hash_password(new_user.password)
-    is_admin = new_user.is_admin if new_user.is_admin != None else False
-    database.execute_query(f"INSERT INTO users (username, password_hash, is_admin) VALUES (?, ?, ?)",
-                           [new_user.username, password_hash, is_admin])
+    is_admin = new_user.is_admin if new_user.is_admin is not None else False
+    database.execute_query(
+        "INSERT INTO users (username, password_hash, is_admin) VALUES (?, ?, ?)",
+        [new_user.username, password_hash, is_admin]
+    )
 
 @router.get("")
 async def get_users(_: User = Depends(get_current_user)) -> list[str]:
     res = database.execute_read_query("SELECT username FROM users;")
+
     usernames = [ entry[0] for entry in res ]
 
     return usernames
@@ -80,19 +125,17 @@ async def update_user(username: str, new_user: UserPatch, user: User = Depends(g
     if user.username != username and not user.is_admin:
         raise HTTPException(status_code=403, detail="Only admins can edit other users")
     if new_user.is_admin and not user.is_admin:
-        raise HTTPException(status_code=403, detail="Only admins can users admin")
+        raise HTTPException(status_code=403, detail="Only admins can set users as admins")
     if new_user.is_admin and username == user.username:
         raise HTTPException(status_code=403, detail="You may only change the admin status of other users")
 
     query = "UPDATE users SET "
-
     values = []
+
     for attr in UserPatch.get_attributes():
         value = getattr(new_user, attr)
-
-        if value == None:
+        if value is None:
             continue
-
         if attr == "password":
             value = hash_password(value)
             attr = "password_hash"
@@ -103,14 +146,16 @@ async def update_user(username: str, new_user: UserPatch, user: User = Depends(g
     if query[-1] == ',':
         query = query[:-1]
 
-    query += f" WHERE username = ?;"
+    query += " WHERE username = ?;"
     values.append(username)
     database.execute_query(query, values)
 
-    # if username was edited, update all flights of that user
+    # If username was edited, update all flights of that user
     if new_user.username:
-        database.execute_query("UPDATE flights SET username = ? WHERE username = ?;",
-                               [new_user.username, username])
+        database.execute_query(
+            "UPDATE flights SET username = ? WHERE username = ?;",
+            [new_user.username, username]
+        )
 
 @router.delete("/{username}", status_code=200)
 async def delete_user(username: str, user: User = Depends(get_current_user)):

--- a/server/auth/utils.py
+++ b/server/auth/utils.py
@@ -2,6 +2,7 @@ from server.models import User
 
 from fastapi.security import OAuth2PasswordBearer
 from argon2 import PasswordHasher
+import secrets
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/auth/token", auto_error=False)
 _ph = PasswordHasher()
@@ -13,11 +14,14 @@ def hash_password(password: str) -> str:
     password_hash = _ph.hash(password)
     return password_hash
 
+def generate_password() -> str:
+    return secrets.token_urlsafe(32)
+
 def get_user(username: str) -> User|None:
     from server.database import database
 
     result = database.execute_read_query(f"SELECT * FROM users WHERE username = ?;", [username])
- 
+
     if not result:
         return None
 

--- a/server/auth/utils.py
+++ b/server/auth/utils.py
@@ -2,7 +2,6 @@ from server.models import User
 
 from fastapi.security import OAuth2PasswordBearer
 from argon2 import PasswordHasher
-import secrets
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/auth/token", auto_error=False)
 _ph = PasswordHasher()
@@ -13,9 +12,6 @@ def verify_password(password: str, password_hash: str) -> bool:
 def hash_password(password: str) -> str:
     password_hash = _ph.hash(password)
     return password_hash
-
-def generate_password() -> str:
-    return secrets.token_urlsafe(32)
 
 def get_user(username: str) -> User|None:
     from server.database import database

--- a/server/environment.py
+++ b/server/environment.py
@@ -19,4 +19,5 @@ def _get_environment_variable(key: str, cast_int: bool = False) -> str|int:
 
 DATA_PATH = _get_environment_variable("DATA_PATH")
 SECRET_KEY = _get_environment_variable("SECRET_KEY")
+AUTH_HEADER = _get_environment_variable("AUTH_HEADER")
 TOKEN_DURATION = int(_get_environment_variable("TOKEN_DURATION", cast_int=True)) # double cast to make linter happy


### PR DESCRIPTION
Closes #88 

With the addition of user authentication added late last year we should add auth header support for users using jetlog behind SSO/IAM solutions.

This PR adds support for an `AUTH_HEADER` environment variable to specify the HTTP header containing the authenticated username. When this header is present, JetLog will blindly trust the provided username and create an account if it does not already exist with a random 32 char password. 

This implementation assumes that JetLog is only accessible via proxy and cannot be bypassed. If `AUTH_HEADER` is not set, authentication will continue as normal.