### PR TITLE
Add Flighty CSV import, use `tini` for cleaner shutdowns, various fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN npm run build
 # RUNTIME
 FROM python:3.11-slim-bookworm
 RUN apt-get update -y && apt-get upgrade -y
-RUN apt-get install -y gosu sqlite3 && rm -rf /var/lib/apt/lists/*
+RUN apt-get install -y gosu tini sqlite3 && rm -rf /var/lib/apt/lists/*
 RUN pip install pipenv
 
 
@@ -50,4 +50,4 @@ EXPOSE ${JETLOG_PORT}/tcp
 
 COPY ./entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
-ENTRYPOINT [ "/entrypoint.sh" ]
+ENTRYPOINT ["/usr/bin/tini", "--", "/entrypoint.sh"]

--- a/client/components/SingleFlight.tsx
+++ b/client/components/SingleFlight.tsx
@@ -168,6 +168,7 @@ export default function SingleFlight({ flightID }) {
                         <p>Purpose: <span>{flight.purpose || "N/A"}</span></p>
                         <p>Airplane: <span>{flight.airplane || "N/A"}</span></p>
                         <p>Airline: <span>{flight.airline ? flight.airline.icao + " - " + flight.airline.name : "N/A"}</span></p>
+                        <p>Tail Number: <span>{flight.tailNumber || "N/A"}</span></p>
                         <p>Flight Number: <span>{flight.flightNumber || "N/A"}</span></p>
                         <p>Notes: {flight.notes ?  <p className="whitespace-pre-line inline">{flight.notes}</p> : "N/A"}</p>
                     </>}

--- a/client/pages/Settings.tsx
+++ b/client/pages/Settings.tsx
@@ -168,6 +168,9 @@ export default function Settings() {
                     <Label text="MyFlightRadar24" />
                     <Input type="file" name="myflightradar24" />
 
+                    <Label text="Flighty" />
+                    <Input type="file" name="flighty" />
+
                     <Label text="Custom CSV" />
                     <Input type="file" name="custom" />
 

--- a/server/internal/airport_utils.py
+++ b/server/internal/airport_utils.py
@@ -1,0 +1,8 @@
+from server.database import database
+
+def get_icao_from_iata(iata: str) -> str | None:
+    result = database.execute_read_query(
+        "SELECT icao FROM airports WHERE LOWER(iata) = LOWER(?);",
+        [iata.strip()]
+    )
+    return result[0][0] if result else None

--- a/server/internal/flight_utils.py
+++ b/server/internal/flight_utils.py
@@ -1,0 +1,13 @@
+from server.database import database
+from server.models import FlightModel
+
+def flight_already_exists(flight: FlightModel, username: str) -> bool:
+    result = database.execute_read_query(
+        """
+        SELECT 1 FROM flights
+        WHERE username = ? AND date = ? AND origin = ? AND destination = ? AND flight_number = ?
+        LIMIT 1;
+        """,
+        [username, flight.date, flight.origin, flight.destination, flight.flight_number]
+    )
+    return len(result) > 0

--- a/server/routers/flights.py
+++ b/server/routers/flights.py
@@ -245,6 +245,11 @@ async def get_flights(id: int|None = None,
     date_filter += " AND " if start and end else ""
     date_filter += f"JULIANDAY(date) < JULIANDAY('{end}')" if end else ""
 
+    if sort == Sort.DATE:
+        sort_clause = f"ORDER BY f.date {order.value}, f.departure_time {order.value}"
+    else:
+        sort_clause = f"ORDER BY f.{sort.value} {order.value}"
+
     query = f"""
         SELECT 
             f.*,
@@ -259,7 +264,7 @@ async def get_flights(id: int|None = None,
         {user_filter}
         {id_filter}
         {date_filter}
-        ORDER BY f.{sort.value} {order.value}
+        {sort_clause}
         LIMIT {limit}
         OFFSET {offset};"""
 

--- a/server/routers/importing.py
+++ b/server/routers/importing.py
@@ -166,6 +166,7 @@ async def import_CSV(csv_type: CSVType,
                 print(f"[{count}] Skipped cancelled flight.")
                 count += 1
                 continue
+
             arrival_str = row_data["Gate Arrival (Actual)"].strip()
             if not arrival_str:
                 print(f"[{count}] Skipped flight with no actual arrival time.")

--- a/server/routers/importing.py
+++ b/server/routers/importing.py
@@ -1,5 +1,7 @@
 from server.models import FlightModel, FlightPurpose, SeatType, ClassType, User
 from server.routers.flights import add_flight
+from server.internal.airport_utils import get_icao_from_iata
+from server.internal.flight_utils import flight_already_exists
 from server.auth.users import get_current_user
 
 from fastapi import APIRouter, Depends, HTTPException, UploadFile
@@ -16,6 +18,7 @@ router = APIRouter(
 
 class CSVType(str, Enum):
     MYFLIGHTRADAR24 = "myflightradar24"
+    FLIGHTY = "flighty"
     CUSTOM = "custom"
 
 @router.post("", status_code=202)
@@ -141,6 +144,116 @@ async def import_CSV(csv_type: CSVType,
                 fail_count += 1
 
             count += 1
+
+    elif csv_type == CSVType.FLIGHTY:
+        count = 0
+        header = []
+        for row in reader:
+            if not row or all(col.strip() == "" for col in row):
+                continue
+
+            if count == 0:
+                header = [col.strip() for col in row]
+                expected = ["Date", "Airline", "Flight", "From", "To", "Dep Terminal", "Dep Gate", "Arr Terminal", "Arr Gate", "Canceled", "Diverted To", "Gate Departure (Scheduled)", "Gate Departure (Actual)", "Take off (Scheduled)", "Take off (Actual)", "Landing (Scheduled)", "Landing (Actual)", "Gate Arrival (Scheduled)", "Gate Arrival (Actual)", "Aircraft Type Name", "Tail Number", "PNR", "Seat", "Seat Type", "Cabin Class", "Flight Reason", "Notes", "Flight Flighty ID", "Airline Flighty ID", "Departure Airport Flighty ID", "Arrival Airport Flighty ID", "Diverted To Airport Flighty ID", "Aircraft Type Flighty ID"]
+                if header != expected:
+                    raise HTTPException(status_code=400, detail="Flighty CSV columns do not match expected structure")
+                count += 1
+                continue
+
+            row_data = dict(zip(header, row))
+
+            if row_data["Canceled"].strip().lower() == "true":
+                print(f"[{count}] Skipped cancelled flight.")
+                count += 1
+                continue
+            arrival_str = row_data["Gate Arrival (Actual)"].strip()
+            if not arrival_str:
+                print(f"[{count}] Skipped flight with no actual arrival time.")
+                count += 1
+                continue
+
+            try:
+                values_dict = {}
+
+                values_dict['date'] = datetime.date.fromisoformat(row_data["Date"])
+                values_dict['airline'] = row_data["Airline"]
+                values_dict['flight_number'] = row_data["Flight"]
+
+                # ICAO code conversion
+                origin_icao = get_icao_from_iata(row_data["From"])
+                destination_icao = get_icao_from_iata(row_data["To"])
+                if not origin_icao or not destination_icao:
+                    raise ValueError(f"Unknown IATA code(s): origin='{row_data['From']}', destination='{row_data['To']}'")
+                values_dict['origin'] = origin_icao
+                values_dict['destination'] = destination_icao
+
+                # Times
+                values_dict['departure_time'] = row_data["Gate Departure (Actual)"][11:16] if row_data["Gate Departure (Actual)"] else None
+                values_dict['arrival_time'] = row_data["Gate Arrival (Actual)"][11:16] if row_data["Gate Arrival (Actual)"] else None
+
+                # Plane & tail number
+                values_dict['airplane'] = row_data["Aircraft Type Name"] if row_data["Aircraft Type Name"] else None
+                values_dict['tail_number'] = row_data["Tail Number"] if row_data["Tail Number"] else None
+
+                # Seat type (window/middle/aisle)
+                seat_type_map = {
+                    "window": SeatType.WINDOW,
+                    "middle": SeatType.MIDDLE,
+                    "aisle": SeatType.AISLE
+                }
+                seat_raw = row_data["Seat Type"].strip().lower()
+                if seat_raw in seat_type_map:
+                    values_dict['seat'] = seat_type_map[seat_raw]
+
+                ticket_class_conversion = {
+                    "BUSINESS": ClassType.BUSINESS,
+                    "FIRST": ClassType.FIRST,
+                    "ECONOMY": ClassType.ECONOMY,
+                    "PREMIUM_ECONOMY": ClassType.ECONOMYPLUS,
+                    "PRIVATE": ClassType.PRIVATE
+                }
+
+                class_raw = row_data["Cabin Class"].strip().upper()
+                if class_raw in ticket_class_conversion:
+                    values_dict['ticket_class'] = ticket_class_conversion[class_raw]
+
+                if row_data["Flight Reason"] and row_data["Flight Reason"].isdigit():
+                    values_dict['purpose'] = list(FlightPurpose)[int(row_data["Flight Reason"]) - 1]
+
+                # Notes + append other flighty data
+                notes = row_data["Notes"].strip() if row_data["Notes"] else ""
+                seat_number = row_data["Seat"].strip() if row_data["Seat"] else ""
+
+                append_lines = []
+
+                if seat_number:
+                   append_lines.append(f"Seat: {seat_number}")
+
+                if row_data["Dep Terminal"]:
+                    append_lines.append(f"Dep Terminal: {row_data['Dep Terminal']}")
+                if row_data["Dep Gate"]:
+                    append_lines.append(f"Dep Gate: {row_data['Dep Gate']}")
+                if row_data["Arr Terminal"]:
+                    append_lines.append(f"Arr Terminal: {row_data['Arr Terminal']}")
+                if row_data["Arr Gate"]:
+                    append_lines.append(f"Arr Gate: {row_data['Arr Gate']}")
+
+                if append_lines:
+                    notes += ("\n" if notes else "") + "\n".join(append_lines)
+
+                values_dict['notes'] = notes if notes else None
+
+                flight = FlightModel(**values_dict)
+                if flight_already_exists(flight, user.username):
+                    print(f"[{count}] Skipped duplicate flight.")
+                    count += 1
+                    continue
+
+                imported_flights.append(flight)
+
+            except Exception as e:
+                print(f"[{count}] Failed to parse: '{e}'")
+                fail_count += 1
 
     print(f"Parsing process complete with {fail_count} failures")
 

--- a/server/routers/importing.py
+++ b/server/routers/importing.py
@@ -33,7 +33,6 @@ async def import_CSV(csv_type: CSVType,
 
     print(f"Parsing CSV into flights...")
     if csv_type == CSVType.MYFLIGHTRADAR24:
-        import re
         count = 0
 
         for row in reader:
@@ -154,7 +153,13 @@ async def import_CSV(csv_type: CSVType,
 
             if count == 0:
                 header = [col.strip() for col in row]
-                expected = ["Date", "Airline", "Flight", "From", "To", "Dep Terminal", "Dep Gate", "Arr Terminal", "Arr Gate", "Canceled", "Diverted To", "Gate Departure (Scheduled)", "Gate Departure (Actual)", "Take off (Scheduled)", "Take off (Actual)", "Landing (Scheduled)", "Landing (Actual)", "Gate Arrival (Scheduled)", "Gate Arrival (Actual)", "Aircraft Type Name", "Tail Number", "PNR", "Seat", "Seat Type", "Cabin Class", "Flight Reason", "Notes", "Flight Flighty ID", "Airline Flighty ID", "Departure Airport Flighty ID", "Arrival Airport Flighty ID", "Diverted To Airport Flighty ID", "Aircraft Type Flighty ID"]
+                expected = ["Date", "Airline", "Flight", "From", "To", "Dep Terminal", "Dep Gate",
+                            "Arr Terminal", "Arr Gate", "Canceled", "Diverted To", "Gate Departure (Scheduled)",
+                            "Gate Departure (Actual)", "Take off (Scheduled)", "Take off (Actual)", "Landing (Scheduled)",
+                            "Landing (Actual)", "Gate Arrival (Scheduled)", "Gate Arrival (Actual)", "Aircraft Type Name",
+                            "Tail Number", "PNR", "Seat", "Seat Type", "Cabin Class", "Flight Reason", "Notes",
+                            "Flight Flighty ID", "Airline Flighty ID", "Departure Airport Flighty ID",
+                            "Arrival Airport Flighty ID", "Diverted To Airport Flighty ID", "Aircraft Type Flighty ID"]
                 if header != expected:
                     raise HTTPException(status_code=400, detail="Flighty CSV columns do not match expected structure")
                 count += 1


### PR DESCRIPTION
This PR mainly adds support for importing flights from Flighty CSV exports

Flighty Import
- Adds a new "flighty" import type
- Validates against Flighty's known column structure
- Skips canceled flights and those without actual arrival times
- Converts IATA codes to ICAO using airport lookup
- Includes basic field mapping for aircraft type, class, seat, notes, etc.
- Additional flighty-specific details (like terminal, gate, seat number) are appended to the notes field when available.
- Avoid importing duplicate flights

Internal Utilities - these are placed in server/internal/ to keep internal logic organized, but feel free to move them elsewhere if you prefer a different structure.
- airport_utils.py
- flight_utils.py

Other fixes found during dev
- Flights are now properly sorted by date and departure time so same-day flights appear in correct order
- Tail number now displays when viewing a flight (previously only visible when editing)
- Switched to tini so the app receives proper SIGTERM signals, enabling faster and cleaner container shutdowns