### PR TITLE
Prioritize shorter names in airport/airline queries

### DIFF
--- a/server/routers/airlines.py
+++ b/server/routers/airlines.py
@@ -16,6 +16,7 @@ async def get_airlines(q: str) -> list[AirlineModel]:
         LOWER(icao) LIKE LOWER(?) OR
         LOWER(iata) LIKE LOWER(?)
         ORDER BY LOWER(name) = LOWER(?) DESC,
+                 LENGTH(name) ASC,
                  LOWER(icao) = LOWER(?) DESC,
                  LOWER(iata) = LOWER(?)
         LIMIT 5;

--- a/server/routers/airports.py
+++ b/server/routers/airports.py
@@ -19,6 +19,7 @@ async def get_airports(q: str) -> list[AirportModel]:
     LOWER(icao) LIKE LOWER(?) 
     ORDER BY LOWER(iata) = LOWER(?) DESC,
              LOWER(name) = LOWER(?) DESC,
+             LENGTH(name) ASC,
              LOWER(municipality) = LOWER(?) DESC,
              LOWER(region) LIKE LOWER(?) DESC,
              LOWER(icao) = LOWER(?) 


### PR DESCRIPTION
Closes #93 

By prioritizing airports and airlines with shorter names, this PR makes sure that crowded substrings in names (such as `Swiss` in airlies) will first give the airlines with the shortest name, so that by typing the fuller name we make sure that all airlines and airports can actually be found.