### PR TITLE
Add ipv6 support

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 set -e
 
+if [ -f "/proc/net/if_inet6" ] ; then
+  ALL_IP="::"
+else
+  ALL_IP="0.0.0.0"
+fi
+
 start_command="python -m \
                uvicorn \
                main:app \
                --app-dir server \
-               --host 0.0.0.0 \
+               --host ${ALL_IP} \
                --port ${JETLOG_PORT} \
                --root-path ${JETLOG_BASE_URL:-/}"
 


### PR DESCRIPTION
Currently the backend listens to 0.0.0.0 making ipv6 impossible. Detect if ipv6 is available and listen to "::" if it's available.