### PR TITLE
Parameterize image names so that other images tags can be easily built

### DIFF
--- a/.github/workflows/docker-ci-pipeline.yaml
+++ b/.github/workflows/docker-ci-pipeline.yaml
@@ -1,18 +1,27 @@
-name: Docker Build and Push
+name: Multi-Arch Docker Publish
 
 on:
-  pull_request:
+  push:
     branches:
       - main
-  push:
+  pull_request:
     branches:
       - main
   release:
     types: [published]
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_REPOSITORY: ${{ vars.IMAGE_REPOSITORY || format('{0}/jetlog', github.repository_owner) }}
+
+permissions:
+  contents: read
+  packages: write
+
 jobs:
-  docker:
+  build-and-push:
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -23,32 +32,27 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to Docker Hub
+      - name: Log in to GHCR
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Process version tag
-        if: github.event_name == 'release'
-        id: version
-        run: |
-          CLEAN_VERSION="${GITHUB_REF_NAME#v}"
-          echo "version=$CLEAN_VERSION" >> $GITHUB_OUTPUT
-
-      - name: Extract metadata for Docker
+      - name: Docker metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ secrets.DOCKERHUB_USERNAME }}/jetlog
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_REPOSITORY }}
           tags: |
-            ${{ github.event_name == 'pull_request' && 'pr-${{ github.event.pull_request.number }}' || '' }}
-            ${{ github.event_name == 'push' && 'experimental' || '' }}
-            ${{ github.event_name == 'release' && 'latest' || '' }}
-            ${{ github.event_name == 'release' && steps.version.outputs.version || '' }}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=sha
 
-      - name: Build and push Docker image
+      - name: Build and push
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -57,3 +61,5 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Hey, being able to build and push this up from my own fork helps me test. I updated the workflow to set the image name based on the repo that it's from automatically, with an option to pass a custom image name. For instance my fork repo will build and push an `adepssimius/jetlog` image, while your repo will continue to build and push an `pbogre/jetlog` image.