### PR TITLE
Remove 'Traveler Details' label for non-admin travelers on new page

### DIFF
--- a/client/pages/New.tsx
+++ b/client/pages/New.tsx
@@ -295,8 +295,7 @@ export default function New() {
                 {!currentUser?.isAdmin && currentUser && (
                     <div className="px-4 pb-2">
                         <div className="container">
-                        <Label text="Traveler Details" />
-                        <TravelerFields username={currentUser.username} />
+                            <TravelerFields username={currentUser.username} />
                         </div>
                     </div>
                 )}


### PR DESCRIPTION
for consistency with other containers not having headers