### PR TITLE
feat: make world map full-size with overlaid UI elements

### DIFF
--- a/client/components/Navbar.tsx
+++ b/client/components/Navbar.tsx
@@ -50,7 +50,7 @@ export default function Navbar() {
     };
 
     return(
-        <nav className="bg-gray-700 list-none">
+        <nav className="bg-gray-700 list-none relative z-20">
             <div className="flex justify-between max-md:hidden">
                 <div className="flex">
                 {[items.home, items.new, items.flights, items.statistics]}

--- a/client/components/WorldMap.tsx
+++ b/client/components/WorldMap.tsx
@@ -139,10 +139,17 @@ export default function WorldMap() {
     }, []);
 
     return (
-        <>
-            <ComposableMap width={1000} height={470}>
+        <div className="w-full h-full">
+            <ComposableMap
+                width={800}
+                height={400}
+                style={{ width: '100%', height: '100%' }}
+                projectionConfig={{
+                    scale: 147,
+                    center: [0, 0]
+                }}
+            >
                 <ZoomableGroup maxZoom={10}
-                               translateExtent={[[0, 0], [1000, 470]]}
                                zoom={initialZoom}
                                center={center}
                                onMove={({zoom: newZoom}) => {
@@ -153,7 +160,7 @@ export default function WorldMap() {
 
                 </ZoomableGroup>
             </ComposableMap>
-        </>
+        </div>
     );
 }
 

--- a/client/pages/Home.tsx
+++ b/client/pages/Home.tsx
@@ -5,12 +5,16 @@ import WorldMap from '../components/WorldMap';
 
 export default function Home() {
     return (
-        <>
-            <ShortStats />
-
-            <div className="md:w-4/5 md:m-auto">
+        <div className="relative -m-4">
+            {/* Map takes full viewport behind other elements */}
+            <div className="fixed inset-0 top-[56px] z-0">
                 <WorldMap />
             </div>
-        </>
+
+            {/* Stats overlay on top of map */}
+            <div className="relative z-10 p-4">
+                <ShortStats />
+            </div>
+        </div>
     );
 }


### PR DESCRIPTION
## Summary

- Makes the world map full-screen instead of fixed 3/4 width
- Navbar and stat pills now overlay on top of the map with proper z-index
- Map still shows entire world view on initial load
- Improves mobile experience by using the full viewport

## Changes

- **Home.tsx**: Changed layout to use fixed positioning for map with z-index layering
- **WorldMap.tsx**: Made map responsive with `width: 100%` and `height: 100%`, removed fixed `translateExtent`
- **Navbar.tsx**: Added `relative z-20` to ensure navbar overlays the map

## Test plan

- [ ] Verify map takes full viewport width on desktop
- [ ] Verify map takes full viewport width on mobile
- [ ] Verify navbar is visible and clickable above map
- [ ] Verify stat pills are visible and readable above map
- [ ] Verify map still zooms and pans correctly
- [ ] Verify map shows entire world on initial load

Closes #49

---
Generated with [Claude Code](https://claude.com/claude-code)