### PR TITLE
feat: replace alert() with toast notifications

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -11,10 +11,12 @@ import Statistics from './pages/Statistics';
 import Settings from './pages/Settings';
 
 import Navbar from './components/Navbar';
+import { ToastProvider } from './components/Toast';
 
 export function App() {
     return (
-        <BrowserRouter basename={BASE_URL}>
+        <ToastProvider>
+            <BrowserRouter basename={BASE_URL}>
             <Routes>
                 <Route path="/login" element={<Login />} />
                 <Route element={
@@ -32,5 +34,6 @@ export function App() {
                 </Route>
             </Routes>
         </BrowserRouter>
+        </ToastProvider>
     );
 }

--- a/client/api.ts
+++ b/client/api.ts
@@ -1,5 +1,6 @@
 import axios, {Axios} from 'axios';
 import TokenStorage from './storage/tokenStorage';
+import { showToast } from './components/Toast';
 
 const config = await fetch('./config').then((response) => response.json())
                                       .catch(() => ({ BASE_URL: '/', ENABLE_EXTERNAL_APIS: true }));
@@ -44,14 +45,14 @@ class APIClass {
                 }
             }
             else {
-                alert("Bad response: " + JSON.stringify(err.response.data));
+                const errorData = err.response.data; const message = typeof errorData === 'object' && errorData.detail ? errorData.detail : JSON.stringify(errorData); showToast('Error: ' + message, 'error');
             }
         }
         else if (err.request) {
-            alert("Bad request: " + JSON.stringify(err.request));
+            showToast('Network error: Unable to reach server', 'error');
         }
         else {
-            alert("Unknown error: " + JSON.stringify(err));
+            showToast('Unknown error: ' + err.message, 'error');
         }
     }
 

--- a/client/api.ts
+++ b/client/api.ts
@@ -45,7 +45,23 @@ class APIClass {
                 }
             }
             else {
-                const errorData = err.response.data; const message = typeof errorData === 'object' && errorData.detail ? errorData.detail : JSON.stringify(errorData); showToast('Error: ' + message, 'error');
+                const errorData = err.response.data;
+
+                if (typeof errorData === 'object' && errorData.detail) {
+                    if (Array.isArray(errorData.detail)) {
+                        errorData.detail.forEach(err =>  {
+                            const message = (err && err.msg) ? String(err.msg) : JSON.stringify(err);
+                            showToast('Error: ' + message, 'error');
+                        })
+                    } else {
+                        const message = errorData.detail;
+                        showToast('Error: ' + message, 'error');
+                    }
+                } else {
+                    const message = JSON.stringify(errorData);
+                    showToast('Error: ' + message, 'error');
+                }
+
             }
         }
         else if (err.request) {

--- a/client/components/FetchConnection.tsx
+++ b/client/components/FetchConnection.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { useState } from 'react';
 import { Button } from '../components/Elements'
+import { useToast } from '../components/Toast';
 import API from '../api';
 import { Flight } from '../models';
 
@@ -15,7 +16,8 @@ interface FetchConnectionProps {
 
 export default function FetchConnection({ name, date, origin, destination, value, onFetched }: FetchConnectionProps) {
     const [searched, setSearched] = useState<boolean>(false);
-    const [connectionFlight, setConnectionFlight] = useState<Flight>(); // only needed for printing flight info
+    const [connectionFlight, setConnectionFlight] = useState<Flight>();
+    const { showToast } = useToast(); // only needed for printing flight info
 
     // if value is initially set, we must
     // find matching flight (only first render)
@@ -69,14 +71,14 @@ export default function FetchConnection({ name, date, origin, destination, value
                                           ${ data.map((f: Flight, i) => `\n[${i}] ${createInstance(f).toString()}`) }`);
 
                 if (!choice) {
-                    alert("Your input must be a valid index!");
+                    showToast('Your input must be a valid index!', 'error');
                     return;
                 }
 
                 const parsed = Number.parseInt(choice);
 
                 if (!Number.isInteger(parsed) || parsed < 0 || parsed > data.length - 1) {
-                    alert("Your input must be a valid index!");
+                    showToast('Your input must be a valid index!', 'error');
                     return;
                 }
 

--- a/client/components/Toast.tsx
+++ b/client/components/Toast.tsx
@@ -62,8 +62,8 @@ function ToastItem({ toast, onRemove }: ToastItemProps) {
             className={`${bgColor} text-white px-4 py-3 rounded-md shadow-lg mb-2 flex items-start gap-2 max-w-sm animate-slide-in`}
             role="alert"
         >
-            <span className="font-bold text-lg leading-none">{icon}</span>
-            <span className="flex-1 break-words whitespace-pre-wrap">{toast.message}</span>
+            <p className="font-bold text-lg leading-none">{icon}</p>
+            <p className="flex-1 break-words whitespace-pre-wrap">{toast.message}</p>
             <button
                 onClick={() => onRemove(toast.id)}
                 className="text-white hover:text-gray-200 font-bold text-lg leading-none ml-2"

--- a/client/components/Toast.tsx
+++ b/client/components/Toast.tsx
@@ -1,0 +1,111 @@
+import React, { createContext, useContext, useState, useCallback, useEffect } from 'react';
+
+export type ToastType = 'success' | 'error' | 'info';
+
+interface Toast {
+    id: string;
+    message: string;
+    type: ToastType;
+}
+
+interface ToastContextType {
+    showToast: (message: string, type: ToastType) => void;
+}
+
+const ToastContext = createContext<ToastContextType | undefined>(undefined);
+
+export function useToast() {
+    const context = useContext(ToastContext);
+    if (!context) {
+        throw new Error('useToast must be used within a ToastProvider');
+    }
+    return context;
+}
+
+let globalShowToast: ((message: string, type: ToastType) => void) | null = null;
+
+export function showToast(message: string, type: ToastType) {
+    if (globalShowToast) {
+        globalShowToast(message, type);
+    } else {
+        console.error('Toast system not initialized:', message);
+    }
+}
+
+interface ToastItemProps {
+    toast: Toast;
+    onRemove: (id: string) => void;
+}
+
+function ToastItem({ toast, onRemove }: ToastItemProps) {
+    useEffect(() => {
+        const timer = setTimeout(() => {
+            onRemove(toast.id);
+        }, 5000);
+        return () => clearTimeout(timer);
+    }, [toast.id, onRemove]);
+
+    const bgColor = {
+        success: 'bg-green-500',
+        error: 'bg-red-500',
+        info: 'bg-blue-500',
+    }[toast.type];
+
+    const icon = {
+        success: '\u2713',
+        error: '\u2717',
+        info: '\u2139',
+    }[toast.type];
+
+    return (
+        <div
+            className={`${bgColor} text-white px-4 py-3 rounded-md shadow-lg mb-2 flex items-start gap-2 max-w-sm animate-slide-in`}
+            role="alert"
+        >
+            <span className="font-bold text-lg leading-none">{icon}</span>
+            <span className="flex-1 break-words whitespace-pre-wrap">{toast.message}</span>
+            <button
+                onClick={() => onRemove(toast.id)}
+                className="text-white hover:text-gray-200 font-bold text-lg leading-none ml-2"
+                aria-label="Close"
+            >
+                &times;
+            </button>
+        </div>
+    );
+}
+
+interface ToastProviderProps {
+    children: React.ReactNode;
+}
+
+export function ToastProvider({ children }: ToastProviderProps) {
+    const [toasts, setToasts] = useState<Toast[]>([]);
+
+    const removeToast = useCallback((id: string) => {
+        setToasts((prev) => prev.filter((toast) => toast.id !== id));
+    }, []);
+
+    const addToast = useCallback((message: string, type: ToastType) => {
+        const id = Math.random().toString(36).slice(2, 10);
+        setToasts((prev) => [...prev, { id, message, type }]);
+    }, []);
+
+    useEffect(() => {
+        globalShowToast = addToast;
+        return () => {
+            globalShowToast = null;
+        };
+    }, [addToast]);
+
+    return (
+        <ToastContext.Provider value={{ showToast: addToast }}>
+            {children}
+            <div className="fixed bottom-4 right-4 z-50 flex flex-col items-end">
+                {toasts.map((toast) => (
+                    <ToastItem key={toast.id} toast={toast} onRemove={removeToast} />
+                ))}
+            </div>
+        </ToastContext.Provider>
+    );
+}

--- a/client/pages/Settings.tsx
+++ b/client/pages/Settings.tsx
@@ -174,7 +174,7 @@ export default function Settings() {
 
         API.post("/flights/airlines_from_callsigns", {})
         .then((data: object) => {
-            showToast(`Connections computed: ${data["amountUpdated"]} updated, ${data["amountSkipped"]} skipped`, 'success');
+            showToast(`Airlines fetched: ${data["amountUpdated"]} updated, ${data["amountSkipped"]} skipped`, 'success');
             setDisableJobs(false);
         })
     }

--- a/client/pages/Settings.tsx
+++ b/client/pages/Settings.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 
 import API, { ENABLE_EXTERNAL_APIS } from '../api';
 import { Heading, Label, Input, Checkbox, Subheading, Button, Dialog, Select } from '../components/Elements'
+import { useToast } from '../components/Toast';
 import ConfigStorage, { ConfigInterface } from '../storage/configStorage';
 import { User } from '../models';
 import TokenStorage from '../storage/tokenStorage';
@@ -94,6 +95,7 @@ export default function Settings() {
     const [allUsers, setAllUsers] = useState<User[]>([]);
     const [disableJobs, setDisableJobs] = useState(false);
     const navigate = useNavigate();
+    const { showToast } = useToast();
 
     useEffect(() => {
         API.get("/users/me")
@@ -162,7 +164,7 @@ export default function Settings() {
 
         API.post("/flights/connections", {})
         .then((data: object) => {
-            alert(`Flights skipped: ${data["amountSkipped"]}\nFlights updated: ${data["amountUpdated"]}`);
+            showToast(`Connections computed: ${data["amountUpdated"]} updated, ${data["amountSkipped"]} skipped`, 'success');
             setDisableJobs(false);
         });
     }
@@ -172,7 +174,7 @@ export default function Settings() {
 
         API.post("/flights/airlines_from_callsigns", {})
         .then((data: object) => {
-            alert(`Flights skipped: ${data["amountSkipped"]}\nFlights updated: ${data["amountUpdated"]}`);
+            showToast(`Connections computed: ${data["amountUpdated"]} updated, ${data["amountSkipped"]} skipped`, 'success');
             setDisableJobs(false);
         })
     }

--- a/client/style.css
+++ b/client/style.css
@@ -15,3 +15,10 @@
         @apply font-mono text-primary-500
     }
 }
+
+/* Toast animation */
+@keyframes slide-in {
+    from { transform: translateX(100%); opacity: 0; }
+    to { transform: translateX(0); opacity: 1; }
+}
+.animate-slide-in { animation: slide-in 0.3s ease-out; }


### PR DESCRIPTION
## Summary
- Replaces all intrusive JavaScript `alert()` calls with toast notifications
- Toasts appear in bottom-right corner and auto-dismiss after 5 seconds
- Added success toasts for completed operations (compute connections, fetch airlines)
- Supports error, success, and info toast types with appropriate styling

## Changes
- Created new `Toast.tsx` component with React Context for state management
- Added global `showToast()` function for non-component code (api.ts)
- Added CSS slide-in animation for toast appearance
- Wrapped app in `ToastProvider` component

Closes #3

## Test plan
- [x] Build succeeds with no TypeScript errors
- [x] Trigger API errors to verify error toasts appear
- [x] Run "Compute flight connections" to verify success toasts
- [x] Run "Fetch missing airlines" to verify success toasts
- [x] Verify toasts auto-dismiss after ~5 seconds
- [x] Verify toasts can be manually dismissed with X button

🤖 Generated with [Claude Code](https://claude.com/claude-code)