### PR TITLE
Add 24-hour clock option for flight time inputs

### DIFF
--- a/client/components/SingleFlight.tsx
+++ b/client/components/SingleFlight.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { Button, Heading, Input, Select, Subheading, TextArea } from '../components/Elements'
 import { Airline, Airport, Flight, User } from '../models';
 import SearchInput from './SearchInput';
+import TimeInput from './TimeInput';
 import API from '../api';
 import ConfigStorage from '../storage/configStorage';
 import { objectFromForm } from '../utils';
@@ -76,8 +77,8 @@ export default function SingleFlight({ flightID }) {
                     { editMode ? 
                     <>
                         <p>Date: <Input type="date" name="date" defaultValue={flight.date} /></p>
-                        <p>Departure Time: <Input type="time" name="departureTime" defaultValue={flight.departureTime} /></p>
-                        <p>Arrival Time: <Input type="time" name="arrivalTime" defaultValue={flight.arrivalTime} /></p>
+                        <p>Departure Time: <TimeInput name="departureTime" defaultValue={flight.departureTime} /></p>
+                        <p>Arrival Time: <TimeInput name="arrivalTime" defaultValue={flight.arrivalTime} /></p>
                         <p>Arrival Date: <Input type="date" name="arrivalDate" defaultValue={flight.arrivalDate}/></p>
                         <p>Duration: <Input type="number" name="duration" placeholder={flight.duration?.toString()}/></p>
                     </>

--- a/client/components/TimeInput.tsx
+++ b/client/components/TimeInput.tsx
@@ -1,0 +1,150 @@
+import React, { useState, useEffect, ChangeEvent } from 'react';
+import ConfigStorage from '../storage/configStorage';
+
+interface TimeInputProps {
+    name?: string;
+    defaultValue?: string;
+    onChange?: ((event: ChangeEvent<HTMLInputElement>) => any) | null;
+    required?: boolean;
+}
+
+// Convert 24-hour time (HH:MM) to 12-hour format
+function to12Hour(time24: string): { time: string; period: 'AM' | 'PM' } {
+    if (!time24) return { time: '', period: 'AM' };
+
+    const [hoursStr, minutes] = time24.split(':');
+    let hours = parseInt(hoursStr, 10);
+    const period: 'AM' | 'PM' = hours >= 12 ? 'PM' : 'AM';
+
+    if (hours === 0) {
+        hours = 12;
+    } else if (hours > 12) {
+        hours = hours - 12;
+    }
+
+    return {
+        time: `${hours.toString().padStart(2, '0')}:${minutes}`,
+        period
+    };
+}
+
+// Convert 12-hour time to 24-hour format
+function to24Hour(time12: string, period: 'AM' | 'PM'): string {
+    if (!time12) return '';
+
+    const [hoursStr, minutes] = time12.split(':');
+    let hours = parseInt(hoursStr, 10);
+
+    if (period === 'AM') {
+        if (hours === 12) {
+            hours = 0;
+        }
+    } else {
+        if (hours !== 12) {
+            hours = hours + 12;
+        }
+    }
+
+    return `${hours.toString().padStart(2, '0')}:${minutes}`;
+}
+
+export default function TimeInput({
+    name,
+    defaultValue,
+    onChange = null,
+    required = false
+}: TimeInputProps) {
+    const use24Hour = ConfigStorage.getSetting('use24HourFormat') === 'true';
+
+    // For 12-hour mode, we need to track the period separately
+    const [period, setPeriod] = useState<'AM' | 'PM'>('AM');
+    const [time12, setTime12] = useState('');
+
+    // Initialize 12-hour values from defaultValue
+    useEffect(() => {
+        if (defaultValue && !use24Hour) {
+            const converted = to12Hour(defaultValue);
+            setTime12(converted.time);
+            setPeriod(converted.period);
+        }
+    }, [defaultValue, use24Hour]);
+
+    // For 24-hour mode, use native time input
+    if (use24Hour) {
+        return (
+            <input
+                className="px-1 mb-4 bg-white rounded-none outline-none font-mono box-border
+                           border-b-2 border-gray-200 focus:border-primary-400"
+                type="time"
+                name={name}
+                defaultValue={defaultValue}
+                onChange={onChange ? onChange : () => {}}
+                required={required}
+            />
+        );
+    }
+
+    // For 12-hour mode, use custom input with AM/PM selector
+    const handleTimeChange = (e: ChangeEvent<HTMLInputElement>) => {
+        const newTime12 = e.target.value;
+        setTime12(newTime12);
+
+        // Convert to 24-hour for the hidden input and callback
+        if (onChange && newTime12) {
+            const time24 = to24Hour(newTime12, period);
+            const syntheticEvent = {
+                ...e,
+                target: {
+                    ...e.target,
+                    value: time24,
+                    name: name
+                }
+            } as ChangeEvent<HTMLInputElement>;
+            onChange(syntheticEvent);
+        }
+    };
+
+    const handlePeriodChange = (e: ChangeEvent<HTMLSelectElement>) => {
+        const newPeriod = e.target.value as 'AM' | 'PM';
+        setPeriod(newPeriod);
+
+        // Update the hidden input value
+        if (onChange && time12) {
+            const time24 = to24Hour(time12, newPeriod);
+            const syntheticEvent = {
+                target: {
+                    value: time24,
+                    name: name
+                }
+            } as ChangeEvent<HTMLInputElement>;
+            onChange(syntheticEvent);
+        }
+    };
+
+    // Calculate the 24-hour value for the hidden input
+    const value24 = time12 ? to24Hour(time12, period) : (defaultValue || '');
+
+    return (
+        <div className="inline-flex items-center gap-1">
+            <input
+                className="px-1 mb-4 bg-white rounded-none outline-none font-mono box-border
+                           border-b-2 border-gray-200 focus:border-primary-400"
+                type="time"
+                value={time12}
+                onChange={handleTimeChange}
+                required={required}
+            />
+            <select
+                className="px-1 py-0.5 mb-4 bg-white rounded-none outline-none font-mono box-border
+                           border-b-2 border-gray-200 focus:border-primary-400"
+                value={period}
+                onChange={handlePeriodChange}
+            >
+                <option value="AM">AM</option>
+                <option value="PM">PM</option>
+            </select>
+            {/* Hidden input to submit the 24-hour value */}
+            <input type="hidden" name={name} value={value24} />
+        </div>
+    );
+}

--- a/client/pages/New.tsx
+++ b/client/pages/New.tsx
@@ -2,7 +2,8 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { Heading, Label, Button, Input, Select, TextArea } from '../components/Elements';
-import SearchInput from '../components/SearchInput'
+import SearchInput from '../components/SearchInput';
+import TimeInput from '../components/TimeInput';
 import API, { ENABLE_EXTERNAL_APIS } from '../api';
 import { objectFromForm } from '../utils';
 import { Airline, Airport, User } from '../models';
@@ -203,14 +204,12 @@ export default function New() {
 
                         <br />
                         <Label text="Departure Time" />
-                        <Input
-                            type="time"
+                        <TimeInput
                             name="departureTime"
                         />
                         <br />
                         <Label text="Arrival Time" />
-                        <Input
-                            type="time"
+                        <TimeInput
                             name="arrivalTime"
                         />
                         <br />

--- a/client/pages/Settings.tsx
+++ b/client/pages/Settings.tsx
@@ -254,6 +254,13 @@ export default function Settings() {
 
                 </div>
 
+                <div className="flex justify-between">
+                    <Label text="Use 24-hour time format" />
+                    <Checkbox name="use24HourFormat"
+                                checked={options.use24HourFormat === "true"}
+                                onChange={changeOption} />
+                </div>
+
                 <hr />
 
                 <Subheading text="Utilities" />

--- a/client/storage/configStorage.ts
+++ b/client/storage/configStorage.ts
@@ -6,13 +6,15 @@ export interface ConfigInterface {
     metricUnits: string;
     localAirportTime: string;
     restrictWorldMap: string;
+    use24HourFormat: string;
 }
 const ConfigKeys = ["frequencyBasedMarker",
                     "frequencyBasedLine",
                     "showVisitedCountries",
                     "metricUnits",
                     "localAirportTime",
-                    "restrictWorldMap"];
+                    "restrictWorldMap",
+                    "use24HourFormat"];
 type Config = typeof ConfigKeys[number];
 
 const defaultConfig: ConfigInterface = {
@@ -22,6 +24,7 @@ const defaultConfig: ConfigInterface = {
     metricUnits: "true",
     localAirportTime: "true",
     restrictWorldMap: "false",
+    use24HourFormat: "false",
 }
 
 class ConfigStorageClass {


### PR DESCRIPTION
## Summary

- Adds a new `use24HourFormat` setting to allow users to toggle between 12-hour (with AM/PM) and 24-hour time formats
- Creates a new `TimeInput` component that conditionally renders either a native time input (24-hour mode) or a time input with AM/PM selector (12-hour mode)
- Integrates the new TimeInput component into the New Flight and Edit Flight forms
- Adds a toggle in Settings under the Customization section

Closes #15

## Test plan

- [ ] Verify the "Use 24-hour time format" checkbox appears in Settings > Customization
- [ ] With 24-hour format disabled (default), verify time inputs show AM/PM selector
- [ ] With 24-hour format enabled, verify time inputs use native 24-hour format
- [ ] Create a new flight with times in both modes and verify they are saved correctly
- [ ] Edit an existing flight's times in both modes and verify changes are saved correctly
- [ ] Verify the setting persists across page reloads (stored in localStorage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)