### PR TITLE
fix(ci): support Docker builds for forked PRs

### DIFF
--- a/.github/workflows/docker-ci-pipeline.yaml
+++ b/.github/workflows/docker-ci-pipeline.yaml
@@ -37,13 +37,19 @@ jobs:
           CLEAN_VERSION="${GITHUB_REF_NAME#v}"
           echo "version=$CLEAN_VERSION" >> $GITHUB_OUTPUT
 
+      - name: Set PR tag
+        if: github.event_name == 'pull_request'
+        id: pr_tag
+        run: |
+          echo "pr_tag=pr-${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+
       - name: Extract metadata for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ secrets.DOCKERHUB_USERNAME }}/jetlog
+          images: ${{ github.repository_owner }}/jetlog
           tags: |
-            ${{ github.event_name == 'pull_request' && 'pr-${{ github.event.pull_request.number }}' || '' }}
+            ${{ steps.pr_tag.outputs.pr_tag || '' }}
             ${{ github.event_name == 'push' && 'experimental' || '' }}
             ${{ github.event_name == 'release' && 'latest' || '' }}
             ${{ github.event_name == 'release' && steps.version.outputs.version || '' }}


### PR DESCRIPTION
## Summary

Make the Docker build job work for pull requests opened from forks.

Forked pull-request workflows do not receive Docker Hub secrets. The workflow used `secrets.DOCKERHUB_USERNAME` to construct the image name, which produced the invalid `/jetlog` reference when the secret was unavailable. The PR tag also used a nested GitHub expression, resulting in an invalid `pr--` tag.

## Changes

- Use `github.repository_owner` for a consistently valid image namespace
- Compute `pr-<number>` in a dedicated workflow step
- Pass the computed output to `docker/metadata-action`
- Continue skipping Docker Hub login and image pushes for pull-request builds
- Preserve the existing experimental and release tag behavior

## Verification

- Workflow YAML parses successfully
- `actionlint` passes
- PR image metadata now resolves to `pbogre/jetlog:pr-<number>` without requiring repository secrets

This failure was surfaced by #157, but the affected Docker metadata logic already exists on `main` and is independent of the automated-testing changes.
